### PR TITLE
[CAP-1] Check flights in FOV boundary

### DIFF
--- a/backend/src/utils/fov.py
+++ b/backend/src/utils/fov.py
@@ -1,12 +1,12 @@
 import math
-from FlightRadar24 import FlightRadar24API
-fr_api = FlightRadar24API()
+import flight_api as fa
+import coord as co
 
 def calculate_fov_size(focal_length, camera_sensor_size, barlow_reducer_factor):
     # calculate the FOV size
-    fov = ((180/math.pi)/(focal_length*barlow_reducer_factor))*camera_sensor_size
+    fov_size = ((180/math.pi)/(focal_length*barlow_reducer_factor))*camera_sensor_size
 
-    return fov
+    return fov_size
 
 # what distance to use? typical altitude of planes?
 def fov_degrees_to_meters(fov_degrees, distance_meters):    
@@ -18,12 +18,17 @@ def fov_degrees_to_meters(fov_degrees, distance_meters):
     
     return fov_meters
 
-def calculate_fov_boundary(fov_size, fov_center_ra, fov_center_dec):  
+def check_flights_in_fov(focal_length, camera_sensor_size, barlow_reducer_factor, fov_center_ra, fov_center_dec):
+    # find radius of the fov
+    fov_size = calculate_fov_size(focal_length, camera_sensor_size, barlow_reducer_factor)
+    radius = fov_degrees_to_meters(fov_size, distance_meters=12801.6)
+
     # use Andrew's function in coord.py  
-    fov_center_lat, fov_center_lon = convert_ra_dec_to_lat_lon(fov_center_ra, fov_center_dec)
+    fov_center_lat, fov_center_lon = co.convert_ra_dec_to_lat_lon(fov_center_ra, fov_center_dec)
 
-    # latitude and longitude for your position and radius for the distance in meters
-    bounds = fr_api.get_bounds_by_point(fov_center_lat, fov_center_lon, fov_size)
-    
-    return bounds
+    flight_info = fa.find_flights_in_circ_boundary(fov_center_lat, fov_center_lon, radius)
 
+    if flight_info:
+        return True
+    else:
+        return False

--- a/backend/src/utils/fov.py
+++ b/backend/src/utils/fov.py
@@ -1,0 +1,29 @@
+import math
+from FlightRadar24 import FlightRadar24API
+fr_api = FlightRadar24API()
+
+def calculate_fov_size(focal_length, camera_sensor_size, barlow_reducer_factor):
+    # calculate the FOV size
+    fov = ((180/math.pi)/(focal_length*barlow_reducer_factor))*camera_sensor_size
+
+    return fov
+
+# what distance to use? typical altitude of planes?
+def fov_degrees_to_meters(fov_degrees, distance_meters):    
+    # convert FOV from degrees to radians
+    fov_radians = math.radians(fov_degrees)
+    
+    # calculate the FOV in meters
+    fov_meters = 2 * distance_meters * math.tan(fov_radians / 2)
+    
+    return fov_meters
+
+def calculate_fov_boundary(fov_size, fov_center_ra, fov_center_dec):  
+    # use Andrew's function in coord.py  
+    fov_center_lat, fov_center_lon = convert_ra_dec_to_lat_lon(fov_center_ra, fov_center_dec)
+
+    # latitude and longitude for your position and radius for the distance in meters
+    bounds = fr_api.get_bounds_by_point(fov_center_lat, fov_center_lon, fov_size)
+    
+    return bounds
+


### PR DESCRIPTION
Input: focal_length, camera_sensor_size, barlow_reducer_factor, fov_center_ra, fov_center_dec
Output: binary result on whether there are flights in the FOV

* Calculate the fov of the telescope
* Pass the fov as input into the flight api to determine if there are flights in the fov

Note: check_flights_in_fov does not work yet since the implementation for convert_ra_dec_to_lat_lon is missing